### PR TITLE
Rename deprecated function

### DIFF
--- a/scripts/sd_controlnet.py
+++ b/scripts/sd_controlnet.py
@@ -314,7 +314,7 @@ def entrypoint(
     )
 
     sd = StableDiffusion()
-    images = sd.run_inference.call(
+    images = sd.run_inference.remote(
         prompt=prompt,
         negative_prompt=negative_prompt,
         batch_size=n,


### PR DESCRIPTION
The `.call` function has been renamed and is now failing runs.
This renames it to the new version - `.remote`.

I ran locally to verify, looks good.